### PR TITLE
Change license format in .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -68,7 +68,7 @@
 
     "access_right": "open",
 
-    "license": "GNU General Public License v2.0",
+    "license": "gpl-2.0-only",
 
 
     "grants": [{"id":"823844"}]


### PR DESCRIPTION
The `license` field in Zenodo metadata only accepts SPDX identifiers (https://spdx.org/licenses/).